### PR TITLE
Removed -W from sphinx-build command

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -48,7 +48,7 @@ recipe = collective.recipe.template
 input = inline:
    #!/bin/bash
    ${buildout:bin-directory}/sphinx-apidoc -o docs/api src/ploneintranet
-   ${buildout:bin-directory}/sphinx-build -W docs docs/html
+   ${buildout:bin-directory}/sphinx-build docs docs/html
 mode = 755
 output = ${buildout:bin-directory}/generate-docs
 


### PR DESCRIPTION
This causes warnings to be promoted to errors. Sphinx warns if nonlocal image URIs are found in the RSTs. As it's common practice to add travis/coveralls "badges" to READMEs, this is quite counter productive
