### PR TITLE
Pinning loremipsum at 1.0.2 to avoid bad eggs.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -74,4 +74,4 @@ zc.buildout = 1.6.3
 plone.app.robotframework = 0.9.2
 z3c.recipe.egg = 1.3.2
 selenium = 2.41.0
-
+loremipsum = 1.0.2


### PR DESCRIPTION
loremipsum releases 1.0.4 and 1.0.5 have a broken "binary release" for linux 64 bit: this release is used by buildout in preference to the working "source releases", and the behavior cannot be changed.

This (hopefully temporary) fix pins the egg at the last version that did not provide the broken binary release.
